### PR TITLE
Make it easier for developers to build locally

### DIFF
--- a/APIClient/APIClient.swift
+++ b/APIClient/APIClient.swift
@@ -31,11 +31,13 @@ final class APIClient: ObservableObject {
     private let userDefaults: UserDefaults?
 
     init() {
-        let baseBundleID = Bundle.main.infoDictionary?["TELEMETRYDECK_DEVELOPER_BUNDLE_ID"] as! String
+        guard let baseBundleID = Bundle.main.infoDictionary?["TELEMETRYDECK_DEVELOPER_BUNDLE_ID"] as? String else {
+            fatalError("TELEMETRYDECK_DEVELOPER_BUNDLE_ID must be set in the Info.plist")
+        }
         let appGroupID = "group.\(baseBundleID).shared"
         let userDefaults = UserDefaults(suiteName: appGroupID)
         self.userDefaults = userDefaults
-        
+
         // Old storage location for user token, if its in there, remove it afterwards
         if let encodedUserToken = UserDefaults.standard.data(forKey: APIClient.userTokenStandardsKey),
            let userToken = try? JSONDecoder.telemetryDecoder.decode(UserTokenDTO.self, from: encodedUserToken) {

--- a/APIClient/APIClient.swift
+++ b/APIClient/APIClient.swift
@@ -28,9 +28,14 @@ final class APIClient: ObservableObject {
             : "https://api.telemetrydeck.com/api/"
     private static let userTokenStandardsKey = "org.breakthesystem.telemetry.viewer.userToken"
 
-    private let userDefaults = UserDefaults(suiteName: "group.org.breakthesystem.telemetry.shared")
+    private let userDefaults: UserDefaults?
 
     init() {
+        let baseBundleID = Bundle.main.infoDictionary?["TELEMETRYDECK_DEVELOPER_BUNDLE_ID"] as! String
+        let appGroupID = "group.\(baseBundleID).shared"
+        let userDefaults = UserDefaults(suiteName: appGroupID)
+        self.userDefaults = userDefaults
+        
         // Old storage location for user token, if its in there, remove it afterwards
         if let encodedUserToken = UserDefaults.standard.data(forKey: APIClient.userTokenStandardsKey),
            let userToken = try? JSONDecoder.telemetryDecoder.decode(UserTokenDTO.self, from: encodedUserToken) {

--- a/Common.xcconfig
+++ b/Common.xcconfig
@@ -1,0 +1,5 @@
+
+// Change this to something that is unique, scoped to your developer account e.g. "com.yourdomain.TelemetryViewer".
+//
+// This will be applied to all the targets and shared App Group settings in all entitlements and Info.plists.
+DEVELOPER_BUNDLE_ID = org.breakthesystem.telemetry

--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ If you want to add or modify a larger feature, please open an issue or a [GitHub
 
 (Of course you're always free to make your personal fork and use that, regardless of our feelings!)
 
+## Building 
+
+You will need to change the development team and bundle ID to build and run the app with your developer account:
+
+1. Open `Common.xcconfig` and change the value of `DEVELOPER_BUNDLE_ID` to something unique to you.
+2. Select all of the targets one by one and switch to "Signing & Capabilities", and set the "Team" to your development team. 
+
+All targets should now build correctly for you.
+
+**Note:** Do not commit these changes / include them in pull requests.
 
 ## Pull Request Process
 
@@ -25,5 +35,6 @@ If you want to add or modify a larger feature, please open an issue or a [GitHub
 2. Try to be as concise as possible. This makes it easier to discuss and evaluate the changes you propose. 
 3. Be attentive. Pull requests are base for discussion and will require your feedback. 
 4. Pull requests without further interaction may be closed at any point.
+5. Do not include changes to `Common.xcconfig` or the `Info.plist` that only exist to allow you to build with your development team.
 
 While your contribution will be under [the license of the project](./LICENSE), be aware that it will most likely end up being part of a compiled binary available in the Apple App Store.

--- a/Telemetry Viewer.xcodeproj/project.pbxproj
+++ b/Telemetry Viewer.xcodeproj/project.pbxproj
@@ -493,6 +493,8 @@
 		2BF2754526AAC5C10051591C /* MacOs12PayloadKeysView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacOs12PayloadKeysView.swift; sourceTree = "<group>"; };
 		2BF2BE412763918E00A79531 /* CreateNewAppViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateNewAppViewModel.swift; sourceTree = "<group>"; };
 		2BF2BE442763921400A79531 /* CreateNewAppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateNewAppView.swift; sourceTree = "<group>"; };
+		4903E9712983EA1500EEDF5E /* Common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
+		4903E9722983EDAA00EEDF5E /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		6351A780277C5F29003AF559 /* EditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorView.swift; sourceTree = "<group>"; };
 		6351A783277C6431003AF559 /* CustomPickers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPickers.swift; sourceTree = "<group>"; };
 		6351A788277C9ED8003AF559 /* InsightDisplayMode+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InsightDisplayMode+Extensions.swift"; sourceTree = "<group>"; };
@@ -1012,6 +1014,8 @@
 		DCE239F624D3687C00053370 = {
 			isa = PBXGroup;
 			children = (
+				4903E9722983EDAA00EEDF5E /* README.md */,
+				4903E9712983EA1500EEDF5E /* Common.xcconfig */,
 				C5F4D31328ACF48000EBB667 /* SwiftUICharts */,
 				2B74555C27230626002CBB45 /* SwiftUIChartsExtensions */,
 				2BD189F6267BCEA900DFDE4D /* UIComponents */,
@@ -1885,7 +1889,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = org.breakthesystem.telemetry.TelemetryDeckMacIntents;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(DEVELOPER_BUNDLE_ID).TelemetryDeckMacIntents";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -1915,7 +1919,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = org.breakthesystem.telemetry.TelemetryDeckMacIntents;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(DEVELOPER_BUNDLE_ID).TelemetryDeckMacIntents";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -1947,7 +1951,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = org.breakthesystem.telemetry.TelemetryDeckMacWidget;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(DEVELOPER_BUNDLE_ID).TelemetryDeckMacWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -1979,7 +1983,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = org.breakthesystem.telemetry.TelemetryDeckMacWidget;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(DEVELOPER_BUNDLE_ID).TelemetryDeckMacWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -2009,7 +2013,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = org.breakthesystem.telemetry.TelemetryDeckWidget;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(DEVELOPER_BUNDLE_ID).TelemetryDeckWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -2041,7 +2045,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = org.breakthesystem.telemetry.TelemetryDeckWidget;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(DEVELOPER_BUNDLE_ID).TelemetryDeckWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -2072,7 +2076,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = org.breakthesystem.telemetry.TelemetryDeckIntents;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(DEVELOPER_BUNDLE_ID).TelemetryDeckIntents";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -2101,7 +2105,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = org.breakthesystem.telemetry.TelemetryDeckIntents;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(DEVELOPER_BUNDLE_ID).TelemetryDeckIntents";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -2114,6 +2118,7 @@
 		};
 		DCE23A1524D3687D00053370 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4903E9712983EA1500EEDF5E /* Common.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -2147,6 +2152,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPER_BUNDLE_ID = "$(inherited)";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -2173,6 +2179,7 @@
 		};
 		DCE23A1624D3687D00053370 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4903E9712983EA1500EEDF5E /* Common.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -2206,6 +2213,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPER_BUNDLE_ID = "$(inherited)";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -2241,7 +2249,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = org.breakthesystem.telemetry;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(DEVELOPER_BUNDLE_ID)";
 				PRODUCT_NAME = "Telemetry Viewer";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
@@ -2267,7 +2275,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = org.breakthesystem.telemetry;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(DEVELOPER_BUNDLE_ID)";
 				PRODUCT_NAME = "Telemetry Viewer";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
@@ -2296,7 +2304,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = org.breakthesystem.telemetry;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(DEVELOPER_BUNDLE_ID)";
 				PRODUCT_NAME = "Telemetry Viewer";
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.0;
@@ -2323,7 +2331,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = org.breakthesystem.telemetry;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(DEVELOPER_BUNDLE_ID)";
 				PRODUCT_NAME = "Telemetry Viewer";
 				SDKROOT = macosx;
 				SWIFT_VERSION = 5.0;

--- a/TelemetryDeckIntents/Info.plist
+++ b/TelemetryDeckIntents/Info.plist
@@ -20,5 +20,7 @@
 		<key>NSExtensionPrincipalClass</key>
 		<string>$(PRODUCT_MODULE_NAME).IntentHandler</string>
 	</dict>
+	<key>TELEMETRYDECK_DEVELOPER_BUNDLE_ID</key>
+	<string>$(DEVELOPER_BUNDLE_ID)</string>
 </dict>
 </plist>

--- a/TelemetryDeckIntents/TelemetryDeckIntents (iOS).entitlements
+++ b/TelemetryDeckIntents/TelemetryDeckIntents (iOS).entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.org.breakthesystem.telemetry.shared</string>
+		<string>group.$(DEVELOPER_BUNDLE_ID).shared</string>
 	</array>
 </dict>
 </plist>

--- a/TelemetryDeckIntents/TelemetryDeckIntents (macOS).entitlements
+++ b/TelemetryDeckIntents/TelemetryDeckIntents (macOS).entitlements
@@ -6,7 +6,7 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.org.breakthesystem.telemetry.shared</string>
+		<string>group.$(DEVELOPER_BUNDLE_ID).shared</string>
 	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>

--- a/TelemetryDeckWidget/Info.plist
+++ b/TelemetryDeckWidget/Info.plist
@@ -7,5 +7,7 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.widgetkit-extension</string>
 	</dict>
+	<key>TELEMETRYDECK_DEVELOPER_BUNDLE_ID</key>
+	<string>$(DEVELOPER_BUNDLE_ID)</string>
 </dict>
 </plist>

--- a/TelemetryDeckWidget/TelemetryDeckWidgetExtension (iOS).entitlements
+++ b/TelemetryDeckWidget/TelemetryDeckWidgetExtension (iOS).entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.org.breakthesystem.telemetry.shared</string>
+		<string>group.$(DEVELOPER_BUNDLE_ID).shared</string>
 	</array>
 </dict>
 </plist>

--- a/TelemetryDeckWidget/TelemetryDeckWidgetExtension (macOS).entitlements
+++ b/TelemetryDeckWidget/TelemetryDeckWidgetExtension (macOS).entitlements
@@ -6,7 +6,7 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.org.breakthesystem.telemetry.shared</string>
+		<string>group.$(DEVELOPER_BUNDLE_ID).shared</string>
 	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>

--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -46,6 +46,8 @@
 	<array>
 		<string>ConfigurationIntent</string>
 	</array>
+	<key>TELEMETRYDECK_DEVELOPER_BUNDLE_ID</key>
+	<string>$(DEVELOPER_BUNDLE_ID)</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/iOS/Telemetry Viewer (iOS).entitlements
+++ b/iOS/Telemetry Viewer (iOS).entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.org.breakthesystem.telemetry.shared</string>
+		<string>group.$(DEVELOPER_BUNDLE_ID).shared</string>
 	</array>
 </dict>
 </plist>

--- a/macOS/Info.plist
+++ b/macOS/Info.plist
@@ -42,5 +42,7 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>TELEMETRYDECK_DEVELOPER_BUNDLE_ID</key>
+	<string>$(DEVELOPER_BUNDLE_ID)</string>
 </dict>
 </plist>


### PR DESCRIPTION
This commit adds a `DEVELOPER_BUNDLE_ID` variable and new `Common.xcconfig` file, with all target configurations and entitlements, and the  access to shared `UserDefaults` changed to use Bundle ID and App Group IDs derived from its value.

The `README` is updated to explain how to get the app building locally using this ID and amending the Team in all the targets.