### PR TITLE
Fix published property updates on wrong thread. #153

### DIFF
--- a/Shared/Insight and Groups/InsightCard.swift
+++ b/Shared/Insight and Groups/InsightCard.swift
@@ -114,7 +114,8 @@ struct InsightCard: View {
             TelemetryManager.send("InsightShown", with: ["insightDisplayMode": displayMode.rawValue])
         }
     }
-
+    
+    @MainActor
     func retrieveResults() async {
         guard loadingState != .loading else { return } // not sufficient
         loadingState = .loading

--- a/Shared/Insight and Groups/QueryView.swift
+++ b/Shared/Insight and Groups/QueryView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 // @State var customQuery: CustomQuery
 
+@MainActor
 class QueryViewModel: ObservableObject {
     let queryService: QueryService
     let customQuery: CustomQuery
@@ -49,7 +50,8 @@ class QueryViewModel: ObservableObject {
 
         do {
             taskID = try await queryService.createTask(forQuery: customQuery)
-            let result = try await queryService.getTaskResult(forTaskID: taskID["queryTaskID"]!)
+            let queryTaskID = taskID["queryTaskID"]
+            let result = try await queryService.getTaskResult(forTaskID: queryTaskID!)
             if result.result != nil {
                 let chartDataSet = try ChartDataSet(fromQueryResultWrapper: result)
                 DispatchQueue.main.async {
@@ -84,6 +86,7 @@ class QueryViewModel: ObservableObject {
     }
 
     /// Asks for the status every 0.5 seconds if current status is running and loads the result if status is successful
+    @MainActor
     func checkIfStillRunning() async {
         switch loadingState {
         case .idle, .loading, .finished:
@@ -96,14 +99,16 @@ class QueryViewModel: ObservableObject {
             loadingState = .loading
 
             do {
-                let taskStatus = try await queryService.getTaskStatus(forTaskID: taskID["queryTaskID"]!)
+                let queryTaskID = taskID["queryTaskID"]
+                let taskStatus = try await queryService.getTaskStatus(forTaskID: queryTaskID!)
 
                 switch taskStatus {
                 case .successful:
                     DispatchQueue.main.async {
                         self.queryTaskStatus = taskStatus
                     }
-                    let result = try await queryService.getTaskResult(forTaskID: taskID["queryTaskID"]!)
+                    let queryTaskID = taskID["queryTaskID"]
+                    let result = try await queryService.getTaskResult(forTaskID: queryTaskID!)
                     let chartDataSet = try ChartDataSet(fromQueryResultWrapper: result)
                     DispatchQueue.main.async {
                         self.queryResult = result
@@ -158,7 +163,8 @@ class QueryViewModel: ObservableObject {
         if queryTaskStatus == .successful {
             loadingState = .loading
             do {
-                let taskStatus = try await queryService.getTaskStatus(forTaskID: taskID["queryTaskID"]!)
+                let queryTaskID = taskID["queryTaskID"]
+                let taskStatus = try await queryService.getTaskStatus(forTaskID: queryTaskID!)
                 switch taskStatus {
                 case .successful:
                     DispatchQueue.main.async {


### PR DESCRIPTION
I'm new to Swift structured concurrency but it looks like some of the async functions called from views are not using @MainActor so their updates come in on the wrong thread when the requests complete. Adding @MainActor resolves it, and I don't think it is pushing all the work onto the main queue as the network requests have their own actor/queue I presume.