### PR TITLE
Mac toolbar fixes (date picker bg, endless animation)

### DIFF
--- a/Shared/App/InsightDataTimeIntervalPicker.swift
+++ b/Shared/App/InsightDataTimeIntervalPicker.swift
@@ -81,6 +81,5 @@ struct InsightDataTimeIntervalPicker: View {
             }
         }
         .buttonStyle(SmallSecondaryButtonStyle())
-
     }
 }

--- a/macOS/InsightGroupsView.swift
+++ b/macOS/InsightGroupsView.swift
@@ -63,27 +63,25 @@ struct InsightGroupsView: View {
                 newGroupButton
             }
 
-            ToolbarItem {
+            ToolbarItemGroup {
                 Button(queryService.timeIntervalDescription) {
                     TelemetryManager.send("showDatePicker")
                     self.showDatePicker = true
                 }.popover(
                     isPresented: self.$showDatePicker,
                     arrowEdge: .bottom
-                ) { InsightDataTimeIntervalPicker().padding() }
-            }
+                ) {
+                    InsightDataTimeIntervalPicker()
+                    .padding()
+                    .background(Material.regular)
+                }
 
-            ToolbarItem {
                 TestingModeToggle()
-            }
 
-            ToolbarItem {
                 if let selectedInsightGroupID = selectedInsightGroupID {
                     NewInsightMenu(appID: appID, selectedInsightGroupID: selectedInsightGroupID)
                 }
-            }
 
-            ToolbarItem {
                 sidebarToggleButton
             }
         }


### PR DESCRIPTION
At least this is a speculative fix for the animation. I cannot get it to happen again, and maybe this different way of configuring the toolbar avoids the issue.