### PR TITLE
Fix insights appearing in sidebar on iPad

### DIFF
--- a/iOS/InsightGroupsView.swift
+++ b/iOS/InsightGroupsView.swift
@@ -109,6 +109,7 @@ struct InsightGroupsView: View {
         }
         .navigationBarTitleDisplayMode(.inline)
         .navigationTitle(appService.app(withID: appID)?.name ?? "Loading...")
+        .navigationViewStyle(.stack)
     }
 
     private var groupSelector: some View {


### PR DESCRIPTION
This small change fixes a bug in the iPad version of the app. The `InsightGroupsView` contains a NavigationView as a workaround: https://github.com/TelemetryDeck/TelemetryViewer/blob/4fac3c1cf0b599ad94bcd66a4ac726d6f9316acf/iOS/InsightGroupsView.swift#L14-L16

However, because NavigationViews are displayed with a sidebar by default on iPad, the Insights are displayed in the sidebar:
![IMG_0396](https://user-images.githubusercontent.com/20423069/221134991-6614b73c-af53-47cd-8bea-7202d0310f95.PNG)
![IMG_0395](https://user-images.githubusercontent.com/20423069/221135002-23027715-afdb-400f-9e38-5ab6bf61cda4.PNG)

Simply changing the navigationViewStyle to .stack fixes this:
![IMG_0393](https://user-images.githubusercontent.com/20423069/221135209-6a4ba0a0-1ddb-4b6f-9474-4b020cf9e0fe.PNG)

The iPhone version of this app is not affected by this change.