### PR TITLE
remove duplicate environmentObject

### DIFF
--- a/iOS/Telemetry_ViewerApp_iOS.swift
+++ b/iOS/Telemetry_ViewerApp_iOS.swift
@@ -38,7 +38,6 @@ struct Telemetry_ViewerApp: App {
                 .environmentObject(insightService)
                 .environmentObject(signalsService)
                 .environmentObject(lexiconService)
-                .environmentObject(orgService)
                 .environmentObject(iconFinderService)
                 .environmentObject(queryService)
         }


### PR DESCRIPTION
Duplicate in .environmentObject List was removed - orgService was inserted twice into the environment.