### PR TITLE
Fix extra padding for widgets on iOS 17

### DIFF
--- a/TelemetryDeckWidget/TelemetryDeckWidget.swift
+++ b/TelemetryDeckWidget/TelemetryDeckWidget.swift
@@ -122,6 +122,7 @@ struct TelemetryDeckWidget: Widget {
         IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: Provider()) { entry in
             TelemetryDeckWidgetEntryView(entry: entry)
         }
+        .contentMarginsDisabled()
         .configurationDisplayName("Telemetry Deck Widget")
         .description("If no Insights are available here, make sure you are logged in. You can search for Insights by name, app, or display type")
     }


### PR DESCRIPTION
iOS 17 added extra padding for the widgets by the system, breaking the layout on iOS 17 devices due to normal padding on older system versions.
This PR disables the new padding and relies only on the original padding applied by the widget view.